### PR TITLE
Add prefixes to category method names

### DIFF
--- a/Algorithm Class/Luhn.h
+++ b/Algorithm Class/Luhn.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSInteger, OLCreditCardType) {
 
 @interface NSString (Luhn)
 
-- (BOOL) isValidCreditCardNumber;
-- (OLCreditCardType) creditCardType;
+- (BOOL) ol_isValidCreditCardNumber;
+- (OLCreditCardType) ol_creditCardType;
 
 @end

--- a/Algorithm Class/Luhn.m
+++ b/Algorithm Class/Luhn.m
@@ -10,11 +10,11 @@
 
 @implementation NSString (Luhn)
 
-- (BOOL) isValidCreditCardNumber {
+- (BOOL) ol_isValidCreditCardNumber {
     return [Luhn validateString:self];
 }
 
-- (OLCreditCardType) creditCardType {
+- (OLCreditCardType) ol_creditCardType {
     return [Luhn typeFromString:self];
 }
 
@@ -39,7 +39,7 @@
 @implementation Luhn
 
 + (OLCreditCardType) typeFromString:(NSString *) string {
-    BOOL valid = [string isValidCreditCardNumber];
+    BOOL valid = [string ol_isValidCreditCardNumber];
     if (!valid) {
         return OLCreditCardTypeInvalid;
     }

--- a/Example Project/Luhn Algorithm (Mod 10)/ViewController.m
+++ b/Example Project/Luhn Algorithm (Mod 10)/ViewController.m
@@ -25,7 +25,7 @@
         return YES;
     }
     
-    BOOL isValid = [self.textField.text isValidCreditCardNumber];
+    BOOL isValid = [self.textField.text ol_isValidCreditCardNumber];
     [self.resultLabel setText:[NSString stringWithFormat:@"The number you entered is %@!", isValid ? @"valid" : @"isn't valid"]];
     
     [UIView animateWithDuration:0.5f delay:0.0f options:UIViewAnimationOptionAutoreverse animations:^{

--- a/Example Project/Tests/Tests.m
+++ b/Example Project/Tests/Tests.m
@@ -40,12 +40,12 @@ describe(@"Algorithm", ^{
             NSString *typeString = dict[@"type"];
             OLCreditCardType actualType = [typeString isEqualToString:@"amex"] ? OLCreditCardTypeAmex : [typeString isEqualToString:@"diners"] ? OLCreditCardTypeDinersClub : [typeString isEqualToString:@"discover"] ? OLCreditCardTypeDiscover : [typeString isEqualToString:@"jcb"] ? OLCreditCardTypeJCB : [typeString isEqualToString:@"mastercard"] ? OLCreditCardTypeMastercard : OLCreditCardTypeVisa;
             
-            BOOL valid = [Luhn validateString:number] && [number isValidCreditCardNumber];
+            BOOL valid = [Luhn validateString:number] && [number ol_isValidCreditCardNumber];
             [[@(valid) should] beTrue];
             
             OLCreditCardType calculatedType = [Luhn typeFromString:number];
             [[@(actualType) should] equal:@(calculatedType)];
-            [[@(calculatedType) should] equal:@([number creditCardType])];
+            [[@(calculatedType) should] equal:@([number ol_creditCardType])];
        });
     }];
     
@@ -54,7 +54,7 @@ describe(@"Algorithm", ^{
             __block BOOL valid = NO;
             __block BOOL excepted = NO;
             @try {
-                valid = [Luhn validateString:obj] && [obj isValidCreditCardNumber];
+                valid = [Luhn validateString:obj] && [obj ol_isValidCreditCardNumber];
             }
             @catch(NSException *exception) {
                 excepted = YES;

--- a/ObjectiveLuhn/Luhn.h
+++ b/ObjectiveLuhn/Luhn.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSInteger, OLCreditCardType) {
 
 @interface NSString (Luhn)
 
-- (BOOL) isValidCreditCardNumber;
-- (OLCreditCardType) creditCardType;
+- (BOOL) ol_isValidCreditCardNumber;
+- (OLCreditCardType) ol_creditCardType;
 
 @end

--- a/ObjectiveLuhn/Luhn.m
+++ b/ObjectiveLuhn/Luhn.m
@@ -10,11 +10,11 @@
 
 @implementation NSString (Luhn)
 
-- (BOOL) isValidCreditCardNumber {
+- (BOOL) ol_isValidCreditCardNumber {
     return [Luhn validateString:self];
 }
 
-- (OLCreditCardType) creditCardType {
+- (OLCreditCardType) ol_creditCardType {
     return [Luhn typeFromString:self];
 }
 
@@ -39,7 +39,7 @@
 @implementation Luhn
 
 + (OLCreditCardType) typeFromString:(NSString *) string {
-    BOOL valid = [string isValidCreditCardNumber];
+    BOOL valid = [string ol_isValidCreditCardNumber];
     if (!valid) {
         return OLCreditCardTypeInvalid;
     }


### PR DESCRIPTION
It's often [recommended](http://nshipster.com/namespacing/) (although far from widely agreed upon) to prefix category method names to protect against name collisions. I'm not sure if the absence of prefixes in the existing code was intentional or not, so if it was, please feel free to ignore this PR. I made the change for myself anyway, so I figured I may as well offer it to you.
