### PR TITLE
Allow passing nil and short strings to +validateString:

### DIFF
--- a/Algorithm Class/Luhn.m
+++ b/Algorithm Class/Luhn.m
@@ -99,9 +99,6 @@
 }
 
 + (BOOL)validateString:(NSString *)string {
-    NSParameterAssert(string != nil);
-    NSParameterAssert(string.length >= 9);
-    
     NSString *formattedString = [string formattedStringForProcessing];
     if (formattedString == nil || formattedString.length < 9) {
         return NO;

--- a/ObjectiveLuhn/Luhn.m
+++ b/ObjectiveLuhn/Luhn.m
@@ -99,9 +99,6 @@
 }
 
 + (BOOL)validateString:(NSString *)string {
-    NSParameterAssert(string != nil);
-    NSParameterAssert(string.length >= 9);
-    
     NSString *formattedString = [string formattedStringForProcessing];
     if (formattedString == nil || formattedString.length < 9) {
         return NO;


### PR DESCRIPTION
I want to validate the credit card number in a UITextField every time the user types a character, so that I can immediately provide them with feedback as soon as they correct any errors. Currently, this fails the assert when the user begins to type in an empty text field (because the `length` is <9). It seems reasonable to return `NO` for a string that is too short or `nil`. If I'm not mistaken, `NSAssert` is usually used to catch programmer errors, which does not seem to apply to this use case.
